### PR TITLE
Fix bugs and remove redundant copies

### DIFF
--- a/include/capnp/fixture.h
+++ b/include/capnp/fixture.h
@@ -24,7 +24,7 @@ private:
     }
 
     kj::Promise<void> getBlob(GetBlobContext context) override {
-      auto blob = ::get_blob(blob_size_);
+      auto& blob = ::get_blob(blob_size_);
       kj::ArrayPtr<unsigned char> arr((unsigned char *)blob.data(),
                                       blob.size());
       context.getResults().setResult(capnp::Data::Reader(arr));

--- a/include/capnp/fixture.h
+++ b/include/capnp/fixture.h
@@ -72,10 +72,8 @@ public:
     blob_size_ = param;
     auto request = client->getBlobRequest();
     auto resultPromise = request.send();
-    std::string s;
-    auto result =
-        resultPromise.wait(client_thing->getWaitScope()).getResult().asChars();
-    benchmark::DoNotOptimize(s = result.begin());
+    auto result = resultPromise.wait(client_thing->getWaitScope());
+    benchmark::DoNotOptimize(result.getResult().size());
   }
 
   void get_structs(int param) {

--- a/include/direct/fixture.h
+++ b/include/direct/fixture.h
@@ -18,10 +18,10 @@ public:
   }
 
   void get_blob(int param) {
-    std::string s;
-    benchmark::DoNotOptimize(s = ::get_blob(param));
+    const std::string* s;
+    benchmark::DoNotOptimize(s = &::get_blob(param));
     std::size_t size;
-    benchmark::DoNotOptimize(size = s.size());
+    benchmark::DoNotOptimize(size = s->size());
   }
 
   void get_structs(int param) {

--- a/include/target_code.h
+++ b/include/target_code.h
@@ -11,7 +11,7 @@
 
 
 int get_answer(int num);
-std::string get_blob(int size);
+const std::string& get_blob(int size);
 
 std::string rand_str(std::size_t length);
 

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -59,9 +59,8 @@ MAKE_BENCHMARK0(grpc_bench, get_answer);
 
 int main(int argc, char *argv[]) {
   printf("Initalizing blob cache...\n");
-  for (std::size_t s = min_size; s < max_size; ++s) {
+  for (std::size_t s = min_size; s <= max_size; s *= multiplier) {
     get_blob(s);
-    s *= multiplier;
   }
 
   printf("Initalizing struct cache...\n");

--- a/src/target_code.cc
+++ b/src/target_code.cc
@@ -8,7 +8,7 @@ int get_answer(int num) {
 
 static std::map<int, std::string> blob_cache;
 
-std::string get_blob(int size) {
+const std::string& get_blob(int size) {
   if (blob_cache.find(size) != end(blob_cache)) {
     return blob_cache[size];
   }
@@ -19,8 +19,8 @@ std::string get_blob(int size) {
     c = static_cast<unsigned char>(rand() % 256);
   }
 
-  blob_cache[size] = s;
-  return s;
+  blob_cache[size] = std::move(s);
+  return blob_cache[size];
 }
 
 std::string rand_str(std::size_t size) {


### PR DESCRIPTION
See individual commits for explanations.

The effects of these changes are not huge. The main problem with the benchmark results as reported at http://szelei.me/rpc-benchmark-part1/ is that you are measuring userspace CPU time only while discarding kernelspace CPU, and it turns out rpclib pushes a lot more of its work into kernelspace than other RPC libraries do, for whatever reason.

On my machine, Cap'n Proto significantly outperforms rpclib on the larger get_blob tests both before and after this change, as would be expected of a zero-copy protocol dealing with large byte blobs.